### PR TITLE
fix! composer.json manual repo definition

### DIFF
--- a/inc/composer.json
+++ b/inc/composer.json
@@ -1,4 +1,10 @@
 {
+    "repositories": {
+        "freekattema/wp-setup": {
+            "type": "vcs",
+            "url": "https://github.com/BureauZIGZAG/wp-theme"
+        }
+    },
     "require": {
         "freekattema/wp-setup": "dev-master"
     }


### PR DESCRIPTION
Fixes where composer coulnd't find the original repository for the `wp-setup` repository.